### PR TITLE
Few updates

### DIFF
--- a/silx/gui/plot/_utils/test/test_dtime_ticklayout.py
+++ b/silx/gui/plot/_utils/test/test_dtime_ticklayout.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -34,25 +34,12 @@ import datetime as dt
 import unittest
 
 
-from silx.gui.plot._utils.ticklayout import _niceNum
 from silx.gui.plot._utils.dtime_ticklayout import (
-    niceNumGeneric, calcTicks, DtUnit, SECONDS_PER_YEAR)
+    calcTicks, DtUnit, SECONDS_PER_YEAR)
 
 
 class DtTestTickLayout(unittest.TestCase):
     """Test ticks layout algorithms"""
-
-    def testNiceNumGen(self):
-        """ Tests if niceNumGeneric givest the same results as _niceNum"""
-
-        value = 0.1
-        for idx in range(30):
-            value = value * 1.5
-
-            niceOld = _niceNum(value)
-            niceNew = niceNumGeneric(value, [1, 2, 5, 10])
-            self.assertEqual(niceNew, niceOld)
-
 
     def testSmallMonthlySpacing(self):
         """ Tests a range that did result in a spacing of less than 1 month.

--- a/silx/gui/plot/_utils/ticklayout.py
+++ b/silx/gui/plot/_utils/ticklayout.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -52,9 +52,7 @@ def numberOfDigits(tickSpacing):
 # Nice Numbers ################################################################
 
 # This is the original niceNum implementation. For the date time ticks a more
-# generic implementation was needed. This gives slightly different value when
-# the isRound paramter is True. See the comments below. It doesn't result in
-# noticable differences.
+# generic implementation was needed.
 #
 # def _niceNum(value, isRound=False):
 #     expvalue = math.floor(math.log10(value))
@@ -79,32 +77,32 @@ def numberOfDigits(tickSpacing):
 #             nicefrac = 10.
 #     return nicefrac * pow(10., expvalue)
 
-def _niceNum(value, isRound=False):
-    """ Calls niceNumGeneric with niceFractions: [1.0, 2.0, 5.0, 10.0]"""
-    return niceNumGeneric(value, [1.0, 2.0, 5.0, 10.0], isRound=isRound)
 
-
-def niceNumGeneric(value, niceFractions, isRound=False):
+def niceNumGeneric(value, niceFractions=None, isRound=False):
     """ A more generic implementation of the _niceNum function
 
-    Allows to the user to specify the fractions instead of using a hardcoded
+    Allows the user to specify the fractions instead of using a hardcoded
     list of [1, 2, 5, 10.0].
     """
     if value == 0:
         return value
 
-    roundFractions = list(niceFractions)
+    if niceFractions is None:  # Use default values
+        niceFractions = 1., 2., 5., 10.
+        roundFractions = (1.5, 3., 7., 10.) if isRound else niceFractions
 
-    if isRound:
-        # Take the average with the next element. The last remains the same.
-        for i in range(len(roundFractions) - 1):
-            roundFractions[i] = (niceFractions[i] + niceFractions[i+1]) / 2
+    else:
+        roundFractions = list(niceFractions)
+        if isRound:
+            # Take the average with the next element. The last remains the same.
+            for i in range(len(roundFractions) - 1):
+                roundFractions[i] = (niceFractions[i] + niceFractions[i+1]) / 2
 
     highest = niceFractions[-1]
     value = float(value)
 
     expvalue = math.floor(math.log(value, highest))
-    frac = value/pow(highest, expvalue)
+    frac = value / pow(highest, expvalue)
 
     for niceFrac, roundFrac in zip(niceFractions, roundFractions):
         if frac <= roundFrac:
@@ -112,7 +110,6 @@ def niceNumGeneric(value, niceFractions, isRound=False):
 
     # should not come here
     assert False, "should not come here"
-
 
 
 def niceNumbers(vMin, vMax, nTicks=5):
@@ -129,8 +126,8 @@ def niceNumbers(vMin, vMax, nTicks=5):
               number of fractional digit to show
     :rtype: tuple
     """
-    vrange = _niceNum(vMax - vMin, False)
-    spacing = _niceNum(vrange / nTicks, True)
+    vrange = niceNumGeneric(vMax - vMin, isRound=False)
+    spacing = niceNumGeneric(vrange / nTicks, isRound=True)
     graphmin = math.floor(vMin / spacing) * spacing
     graphmax = math.ceil(vMax / spacing) * spacing
     nfrac = numberOfDigits(spacing)

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -1548,11 +1548,11 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
     # Graph axes
 
-    def isXAxisTimeZone(self):
-        return self._plotFrame.xAxis.getTimeZone
+    def getXAxisTimeZone(self):
+        return self._plotFrame.xAxis.timeZone
 
     def setXAxisTimeZone(self, tz):
-        self._plotFrame.xAxis.getTimeZone = tz
+        self._plotFrame.xAxis.timeZone = tz
 
     def isXAxisTimeSeries(self):
         return self._plotFrame.xAxis.isTimeSeries

--- a/silx/gui/plot/backends/glutils/GLPlotFrame.py
+++ b/silx/gui/plot/backends/glutils/GLPlotFrame.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -121,6 +121,7 @@ class PlotAxis(object):
     def timeZone(self, tz):
         """Sets dateetime.tzinfo that is used if this axis plots date times."""
         self._timeZone = tz
+        self._dirtyTicks()
 
     @property
     def isTimeSeries(self):

--- a/silx/gui/plot/items/axis.py
+++ b/silx/gui/plot/items/axis.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -364,6 +364,7 @@ class XAxis(Axis):
             raise TypeError("tz must be a dt.tzinfo object, None or 'UTC'.")
 
         self._plot._backend.setXAxisTimeZone(tz)
+        self._plot._setDirtyPlot()
 
     def getTickMode(self):
         if self._plot._backend.isXAxisTimeSeries():


### PR DESCRIPTION
This PR:
- fixes a typo for accessing the timezone property name in OpenGL backend
- raises plot/backend dirty flags to redraw the plot when changing the timezone
- uses `niceNumGeneric` instead of `_niceNum`. I also made `niceNumGeneric` using the same "roundFractions" as `_niceNum` by default. This is probably useless as both ways looks quite the same. Anyway, as for datetime you always provide the niceFractions parameter it should not change anything.